### PR TITLE
Remove sudo from pip install instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git clone https://github.com/avapolzin/spike.git
 
 cd spike
 
-sudo pip install .
+pip install .
 
 ````
 or 


### PR DESCRIPTION
This is a minor fix sparked by a quick check following the submission to JOSS. Users almost certainly never want to install using `sudo pip`. This may interfere with how the operating system's Python packages are set up. Users should install either into some sort of virtual environment (with `pip install ...`) or into the global user environment (with `pip install ... --user`).

Running `sudo pip install ...` for me already emits this warning:
```
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager, possibly rendering your system unusable.It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
```

I don't know why the GitHub UI changed line 109... Maybe there was no newline?